### PR TITLE
[BE] #72 알림 수신 클라이언트가 없을 경우 NPE 발생

### DIFF
--- a/feedbook/src/main/java/com/guardjo/feedbook/util/FeedNotificationUtil.java
+++ b/feedbook/src/main/java/com/guardjo/feedbook/util/FeedNotificationUtil.java
@@ -24,11 +24,13 @@ public class FeedNotificationUtil {
         log.debug("Send Alarm Event, accountId = {}", accountId);
         AlarmSubscriber subscriber = alarmSubscriberRepository.getClient(accountId);
 
-        try {
-            subscriber.send("Update Alarm");
-        } catch (IOException e) {
-            log.warn("Failed to send Alarm Event, accountId = {}", accountId);
-            alarmSubscriberRepository.deleteClient(accountId);
+        if (Objects.nonNull(subscriber)) {
+            try {
+                subscriber.send("Update Alarm");
+            } catch (IOException e) {
+                log.warn("Failed to send Alarm Event, accountId = {}", accountId);
+                alarmSubscriberRepository.deleteClient(accountId);
+            }
         }
     }
 


### PR DESCRIPTION
- 알림 페이지를 보는 계정이 없어 SSE클라이언트가 없을 때, 알림 발생 시 처리할 클라이언트를 찾지 못하는 오류 발생
- 관련 시나리오 예외 처리

closes #72 