### PR TITLE
Bugfix/#75 reafactoring auth error exception response

### DIFF
--- a/feedbook/src/main/java/com/guardjo/feedbook/config/auth/JwtFilter.java
+++ b/feedbook/src/main/java/com/guardjo/feedbook/config/auth/JwtFilter.java
@@ -9,11 +9,11 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.StringUtils;
+import org.springframework.web.cors.CorsUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
@@ -29,7 +29,7 @@ public class JwtFilter extends OncePerRequestFilter {
             ServletException,
             IOException {
 
-        if (!(request.getMethod().equals(HttpMethod.OPTIONS.name()) || request.getRequestURI().equals(UrlContext.LOGIN_URL) || request.getRequestURI().equals(UrlContext.SIGNUP_URL))) {
+        if (!(CorsUtils.isPreFlightRequest(request) || request.getRequestURI().equals(UrlContext.LOGIN_URL) || request.getRequestURI().equals(UrlContext.SIGNUP_URL))) {
             String token = request.getHeader(HttpHeaders.AUTHORIZATION);
 
             if (!StringUtils.hasText(token)) {

--- a/feedbook/src/main/java/com/guardjo/feedbook/controller/BaseControllerHandler.java
+++ b/feedbook/src/main/java/com/guardjo/feedbook/controller/BaseControllerHandler.java
@@ -1,76 +1,60 @@
 package com.guardjo.feedbook.controller;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
-
-import com.guardjo.feedbook.controller.response.BaseResponse;
 import com.guardjo.feedbook.exception.DuplicateUsernameException;
 import com.guardjo.feedbook.exception.EntityNotFoundException;
 import com.guardjo.feedbook.exception.InvalidRequestException;
 import com.guardjo.feedbook.exception.WrongPasswordException;
-
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 @RestControllerAdvice(basePackageClasses = {
-	AccountController.class,
-	FeedController.class
+        AccountController.class,
+        FeedController.class
 })
 @Slf4j
 public class BaseControllerHandler extends ResponseEntityExceptionHandler {
-	@ExceptionHandler(value = {
-		IllegalArgumentException.class
-	})
-	public BaseResponse<String> handleBadRequest(Exception e) {
-		log.warn("Exception : BadRequest, ", e);
-		return BaseResponse.<String>builder()
-			.status(HttpStatus.BAD_REQUEST.name())
-			.body(e.getMessage())
-			.build();
-	}
+    @ExceptionHandler(value = {
+            IllegalArgumentException.class
+    })
+    public ResponseEntity<String> handleBadRequest(Exception e) {
+        log.warn("Exception : BadRequest, ", e);
 
-	@ExceptionHandler(value = {
-		WrongPasswordException.class
-	})
-	public BaseResponse<String> handleUnauthorize(Exception e) {
-		log.warn("Exception : Unauthorize, ", e);
-		return BaseResponse.<String>builder()
-			.status(HttpStatus.UNAUTHORIZED.name())
-			.body(e.getMessage())
-			.build();
-	}
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+    }
 
-	@ExceptionHandler(value = {
-		InvalidRequestException.class
-	})
-	public BaseResponse<String> handleForbidden(Exception e) {
-		log.warn("Exception : Forbidden, ", e);
-		return BaseResponse.<String>builder()
-			.status(HttpStatus.FORBIDDEN.name())
-			.body(e.getMessage())
-			.build();
-	}
+    @ExceptionHandler(value = {
+            WrongPasswordException.class
+    })
+    public ResponseEntity<String> handleUnauthorized(Exception e) {
+        log.warn("Exception : Unauthorize, ", e);
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
+    }
 
-	@ExceptionHandler(value = {
-		EntityNotFoundException.class
-	})
-	public BaseResponse<String> handleNotFound(Exception e) {
-		log.warn("Exception : NotFound, ", e);
-		return BaseResponse.<String>builder()
-			.status(HttpStatus.NOT_FOUND.name())
-			.body(e.getMessage())
-			.build();
-	}
+    @ExceptionHandler(value = {
+            InvalidRequestException.class
+    })
+    public ResponseEntity<String> handleForbidden(Exception e) {
+        log.warn("Exception : Forbidden, ", e);
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(e.getMessage());
+    }
 
-	@ExceptionHandler(value = {
-		DuplicateUsernameException.class
-	})
-	public BaseResponse<String> handleConflict(Exception e) {
-		log.warn("Exception : Conflict, ", e);
-		return BaseResponse.<String>builder()
-			.status(HttpStatus.CONFLICT.name())
-			.body(e.getMessage())
-			.build();
-	}
+    @ExceptionHandler(value = {
+            EntityNotFoundException.class
+    })
+    public ResponseEntity<String> handleNotFound(Exception e) {
+        log.warn("Exception : NotFound, ", e);
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+    }
+
+    @ExceptionHandler(value = {
+            DuplicateUsernameException.class
+    })
+    public ResponseEntity<String> handleConflict(Exception e) {
+        log.warn("Exception : Conflict, ", e);
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
+    }
 }

--- a/feedbook/src/main/java/com/guardjo/feedbook/util/JwtProvider.java
+++ b/feedbook/src/main/java/com/guardjo/feedbook/util/JwtProvider.java
@@ -1,85 +1,87 @@
 package com.guardjo.feedbook.util;
 
+import com.guardjo.feedbook.config.JwtProperties;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.stereotype.Component;
+
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Date;
 
-import org.springframework.stereotype.Component;
-
-import com.guardjo.feedbook.config.JwtProperties;
-
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.JwtParser;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
-import io.jsonwebtoken.security.Keys;
-
 @Component
 public class JwtProvider {
-	private final Key jwtSecret;
-	private final long expiredTime;
-	private final String claimKeyName;
-	private final String headerPrefix;
+    private final Key jwtSecret;
+    private final long expiredTime;
+    private final String claimKeyName;
+    private final String headerPrefix;
 
-	public JwtProvider(JwtProperties jwtProperties) {
-		this.jwtSecret = encodeKey(jwtProperties.secret());
-		this.expiredTime = jwtProperties.expiredTime();
-		this.claimKeyName = jwtProperties.claimKeyName();
-		this.headerPrefix = jwtProperties.headerPrefix();
-	}
+    public JwtProvider(JwtProperties jwtProperties) {
+        this.jwtSecret = encodeKey(jwtProperties.secret());
+        this.expiredTime = jwtProperties.expiredTime();
+        this.claimKeyName = jwtProperties.claimKeyName();
+        this.headerPrefix = jwtProperties.headerPrefix();
+    }
 
-	/**
-	 * 사용자 식별키를 기준으로 JWT 토큰을 발급한다.
-	 * @param username 사용자 식별아이디
-	 * @return JWT 토큰
-	 */
-	public String createToken(String username) {
-		Claims claims = Jwts.claims();
-		claims.put(claimKeyName, username);
-		Date now = new Date();
+    /**
+     * 사용자 식별키를 기준으로 JWT 토큰을 발급한다.
+     *
+     * @param username 사용자 식별아이디
+     * @return JWT 토큰
+     */
+    public String createToken(String username) {
+        Claims claims = Jwts.claims();
+        claims.put(claimKeyName, username);
+        Date now = new Date();
 
-		return Jwts.builder()
-			.claim(claimKeyName, username)
-			.setIssuedAt(now)
-			.setExpiration(new Date(now.getTime() + expiredTime))
-			.signWith(jwtSecret, SignatureAlgorithm.HS256)
-			.compact();
-	}
+        return Jwts.builder()
+                .claim(claimKeyName, username)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + expiredTime))
+                .signWith(jwtSecret, SignatureAlgorithm.HS256)
+                .compact();
+    }
 
-	/**
-	 * 토큰 만료 여부 확인
-	 * @param token 만료 여부 확인할 JWT 토큰
-	 * @return 만료 여부
-	 */
-	public boolean isExpired(String token) {
-		Claims claims = getClaims(token);
+    /**
+     * 토큰 만료 여부 확인
+     *
+     * @param token 만료 여부 확인할 JWT 토큰
+     * @return 만료 여부
+     */
+    public boolean isExpired(String token) {
+        try {
+            Claims claims = getClaims(token);
+            return claims.getExpiration().before(new Date());
 
-		return claims.getExpiration().before(new Date());
-	}
+        } catch (ExpiredJwtException e) {
+            return true;
+        }
+    }
 
-	/**
-	 * 토큰 내 username 조회
-	 * @param token JWT 토큰
-	 * @return 토큰 내 사용자 식별값 반환
-	 */
-	public String getUsername(String token) {
-		Claims claims = getClaims(token);
+    /**
+     * 토큰 내 username 조회
+     *
+     * @param token JWT 토큰
+     * @return 토큰 내 사용자 식별값 반환
+     */
+    public String getUsername(String token) {
+        Claims claims = getClaims(token);
 
-		return (String)claims.get(claimKeyName);
-	}
+        return (String) claims.get(claimKeyName);
+    }
 
-	private Claims getClaims(String token) {
-		token = token.replace(headerPrefix, "");
+    private Claims getClaims(String token) {
+        token = token.replace(headerPrefix, "");
 
-		JwtParser jwtParser = Jwts.parserBuilder()
-			.setSigningKey(this.jwtSecret)
-			.build();
+        JwtParser jwtParser = Jwts.parserBuilder()
+                .setSigningKey(this.jwtSecret)
+                .build();
 
-		return jwtParser.parseClaimsJws(token)
-			.getBody();
-	}
+        return jwtParser.parseClaimsJws(token)
+                .getBody();
+    }
 
-	private Key encodeKey(String plainKey) {
-		return Keys.hmacShaKeyFor(plainKey.getBytes(StandardCharsets.UTF_8));
-	}
+    private Key encodeKey(String plainKey) {
+        return Keys.hmacShaKeyFor(plainKey.getBytes(StandardCharsets.UTF_8));
+    }
 }

--- a/feedbook/src/test/java/com/guardjo/feedbook/controller/AccountControllerTest.java
+++ b/feedbook/src/test/java/com/guardjo/feedbook/controller/AccountControllerTest.java
@@ -1,15 +1,14 @@
 package com.guardjo.feedbook.controller;
 
-import static org.assertj.core.api.AssertionsForClassTypes.*;
-import static org.mockito.BDDMockito.*;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
-import java.nio.charset.StandardCharsets;
-import java.util.stream.Stream;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.guardjo.feedbook.config.TestSecurityConfig;
+import com.guardjo.feedbook.controller.request.LoginRequest;
+import com.guardjo.feedbook.controller.request.SignupRequest;
+import com.guardjo.feedbook.controller.response.BaseResponse;
+import com.guardjo.feedbook.exception.DuplicateUsernameException;
+import com.guardjo.feedbook.exception.EntityNotFoundException;
+import com.guardjo.feedbook.exception.WrongPasswordException;
+import com.guardjo.feedbook.service.AccountService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -23,192 +22,160 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.guardjo.feedbook.config.TestSecurityConfig;
-import com.guardjo.feedbook.controller.request.LoginRequest;
-import com.guardjo.feedbook.controller.request.SignupRequest;
-import com.guardjo.feedbook.controller.response.BaseResponse;
-import com.guardjo.feedbook.exception.DuplicateUsernameException;
-import com.guardjo.feedbook.exception.EntityNotFoundException;
-import com.guardjo.feedbook.exception.WrongPasswordException;
-import com.guardjo.feedbook.service.AccountService;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(controllers = AccountController.class)
 @Import(TestSecurityConfig.class)
 class AccountControllerTest {
-	@Autowired
-	private MockMvc mockMvc;
-	@Autowired
-	private ObjectMapper objectMapper;
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
 
-	@MockBean
-	private AccountService accountService;
+    @MockBean
+    private AccountService accountService;
 
-	@DisplayName("POST : " + UrlContext.SIGNUP_URL + ": 정상")
-	@Test
-	void test_signup() throws Exception {
-		String username = "test";
-		String nickname = "tester";
-		String password = "1234";
-		SignupRequest signupRequest = new SignupRequest(username, nickname, password);
-		String content = objectMapper.writeValueAsString(signupRequest);
-		BaseResponse<String> expected = BaseResponse.defaultSuccesses();
+    @DisplayName("POST : " + UrlContext.SIGNUP_URL + ": 정상")
+    @Test
+    void test_signup() throws Exception {
+        String username = "test";
+        String nickname = "tester";
+        String password = "1234";
+        SignupRequest signupRequest = new SignupRequest(username, nickname, password);
+        String content = objectMapper.writeValueAsString(signupRequest);
+        BaseResponse<String> expected = BaseResponse.defaultSuccesses();
 
-		willDoNothing().given(accountService).createAccount(eq(username), eq(nickname), eq(password));
+        willDoNothing().given(accountService).createAccount(eq(username), eq(nickname), eq(password));
 
-		String response = mockMvc.perform(post(UrlContext.SIGNUP_URL)
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(content)
-				.with(csrf())
-			).andDo(print())
-			.andExpect(status().isOk())
-			.andReturn()
-			.getResponse()
-			.getContentAsString(StandardCharsets.UTF_8);
+        String response = mockMvc.perform(post(UrlContext.SIGNUP_URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(content)
+                        .with(csrf())
+                ).andDo(print())
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString(StandardCharsets.UTF_8);
 
-		BaseResponse<String> actual = objectMapper.readValue(response, BaseResponse.class);
+        BaseResponse<String> actual = objectMapper.readValue(response, BaseResponse.class);
 
-		assertThat(actual).isEqualTo(expected);
+        assertThat(actual).isEqualTo(expected);
 
-		then(accountService).should().createAccount(eq(username), eq(nickname), eq(password));
-	}
+        then(accountService).should().createAccount(eq(username), eq(nickname), eq(password));
+    }
 
-	@DisplayName("POST : " + UrlContext.SIGNUP_URL + ": 입력값이 올바르지 않는 경우")
-	@Test
-	void test_signup_badRequest() throws Exception {
-		String username = "test";
-		String nickname = "tester";
-		String password = null;
-		SignupRequest signupRequest = new SignupRequest(username, nickname, password);
-		String content = objectMapper.writeValueAsString(signupRequest);
+    @DisplayName("POST : " + UrlContext.SIGNUP_URL + ": 입력값이 올바르지 않는 경우")
+    @Test
+    void test_signup_badRequest() throws Exception {
+        String username = "test";
+        String nickname = "tester";
+        String password = null;
+        SignupRequest signupRequest = new SignupRequest(username, nickname, password);
+        String content = objectMapper.writeValueAsString(signupRequest);
 
-		String response = mockMvc.perform(post(UrlContext.SIGNUP_URL)
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(content)
-				.with(csrf())
-			).andDo(print())
-			.andExpect(status().isOk())
-			.andReturn()
-			.getResponse()
-			.getContentAsString(StandardCharsets.UTF_8);
+        mockMvc.perform(post(UrlContext.SIGNUP_URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(content)
+                        .with(csrf())
+                ).andDo(print())
+                .andExpect(status().isBadRequest());
+    }
 
-		BaseResponse<String> actual = objectMapper.readValue(response, BaseResponse.class);
+    @DisplayName("POST : " + UrlContext.SIGNUP_URL + ": 이미 가입된 정보 요청")
+    @Test
+    void test_signup_duplicate() throws Exception {
+        String username = "test";
+        String nickname = "tester";
+        String password = "1234";
+        SignupRequest signupRequest = new SignupRequest(username, nickname, password);
+        String content = objectMapper.writeValueAsString(signupRequest);
 
-		assertThat(actual).isNotNull();
-		assertThat(actual.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.name());
-	}
+        willThrow(new DuplicateUsernameException(username)).given(accountService).createAccount(eq(username), eq(nickname), eq(password));
 
-	@DisplayName("POST : " + UrlContext.SIGNUP_URL + ": 이미 가입된 정보 요청")
-	@Test
-	void test_signup_duplicate() throws Exception {
-		String username = "test";
-		String nickname = "tester";
-		String password = "1234";
-		SignupRequest signupRequest = new SignupRequest(username, nickname, password);
-		String content = objectMapper.writeValueAsString(signupRequest);
+        mockMvc.perform(post(UrlContext.SIGNUP_URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(content)
+                        .with(csrf())
+                ).andDo(print())
+                .andExpect(status().isConflict());
 
-		willThrow(new DuplicateUsernameException(username)).given(accountService).createAccount(eq(username), eq(nickname), eq(password));
+        then(accountService).should().createAccount(eq(username), eq(nickname), eq(password));
+    }
 
-		String response = mockMvc.perform(post(UrlContext.SIGNUP_URL)
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(content)
-				.with(csrf())
-			).andDo(print())
-			.andExpect(status().isOk())
-			.andReturn()
-			.getResponse()
-			.getContentAsString(StandardCharsets.UTF_8);
+    @DisplayName("POST : " + UrlContext.LOGIN_URL + " : 정상")
+    @Test
+    void test_login() throws Exception {
+        String username = "test123";
+        String password = "1234";
+        LoginRequest loginRequest = new LoginRequest(username, password);
+        String content = objectMapper.writeValueAsString(loginRequest);
+        String expected = "test-token";
 
-		BaseResponse<String> actual = objectMapper.readValue(response, BaseResponse.class);
+        given(accountService.login(eq(username), eq(password))).willReturn(expected);
 
-		assertThat(actual).isNotNull();
-		assertThat(actual.getStatus()).isEqualTo(HttpStatus.CONFLICT.name());
+        String response = mockMvc.perform(post(UrlContext.LOGIN_URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(content)
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andReturn()
+                .getResponse()
+                .getContentAsString(StandardCharsets.UTF_8);
 
-		then(accountService).should().createAccount(eq(username), eq(nickname), eq(password));
-	}
+        BaseResponse<String> actual = objectMapper.readValue(response, BaseResponse.class);
 
-	@DisplayName("POST : " + UrlContext.LOGIN_URL + " : 정상")
-	@Test
-	void test_login() throws Exception {
-		String username = "test123";
-		String password = "1234";
-		LoginRequest loginRequest = new LoginRequest(username, password);
-		String content = objectMapper.writeValueAsString(loginRequest);
-		String expected = "test-token";
+        assertThat(actual.getBody()).isEqualTo(expected);
 
-		given(accountService.login(eq(username), eq(password))).willReturn(expected);
+        then(accountService).should().login(eq(username), eq(password));
+    }
 
-		String response = mockMvc.perform(post(UrlContext.LOGIN_URL)
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(content)
-				.with(csrf()))
-			.andExpect(status().isOk())
-			.andDo(print())
-			.andReturn()
-			.getResponse()
-			.getContentAsString(StandardCharsets.UTF_8);
+    @DisplayName("POST : " + UrlContext.LOGIN_URL + " : 아이디가 없거나 비밀번호가 틀린 경우")
+    @ParameterizedTest
+    @MethodSource("loginArguments")
+    void test_login_not_found_or_unautorized(Class<? extends Exception> e, HttpStatus httpStatus) throws Exception {
+        String username = "test123";
+        String password = "1234";
+        LoginRequest loginRequest = new LoginRequest(username, password);
+        String content = objectMapper.writeValueAsString(loginRequest);
 
-		BaseResponse<String> actual = objectMapper.readValue(response, BaseResponse.class);
+        given(accountService.login(eq(username), eq(password))).willThrow(e);
 
-		assertThat(actual.getBody()).isEqualTo(expected);
+        mockMvc.perform(post(UrlContext.LOGIN_URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(content)
+                        .with(csrf()))
+                .andExpect(status().is(httpStatus.value()));
 
-		then(accountService).should().login(eq(username), eq(password));
-	}
+        then(accountService).should().login(eq(username), eq(password));
+    }
 
-	@DisplayName("POST : " + UrlContext.LOGIN_URL + " : 아이디가 없거나 비밀번호가 틀린 경우")
-	@ParameterizedTest
-	@MethodSource("loginArguments")
-	void test_login_not_found_or_unautorized(Class<? extends Exception> e, HttpStatus httpStatus) throws Exception {
-		String username = "test123";
-		String password = "1234";
-		LoginRequest loginRequest = new LoginRequest(username, password);
-		String content = objectMapper.writeValueAsString(loginRequest);
+    @DisplayName("POST : " + UrlContext.LOGIN_URL + " : 입력값이 올바르지 않는 경우")
+    @Test
+    void test_login_bad_request() throws Exception {
+        String username = "test123";
+        LoginRequest loginRequest = new LoginRequest(username, null);
+        String content = objectMapper.writeValueAsString(loginRequest);
 
-		given(accountService.login(eq(username), eq(password))).willThrow(e);
+        mockMvc.perform(post(UrlContext.LOGIN_URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(content)
+                        .with(csrf()))
+                .andExpect(status().isBadRequest());
+    }
 
-		String response = mockMvc.perform(post(UrlContext.LOGIN_URL)
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(content)
-				.with(csrf()))
-			.andExpect(status().isOk())
-			.andDo(print())
-			.andReturn()
-			.getResponse()
-			.getContentAsString(StandardCharsets.UTF_8);
-
-		BaseResponse<String> actual = objectMapper.readValue(response, BaseResponse.class);
-
-		assertThat(actual.getStatus()).isEqualTo(httpStatus.name());
-
-		then(accountService).should().login(eq(username), eq(password));
-	}
-
-	@DisplayName("POST : " + UrlContext.LOGIN_URL + " : 입력값이 올바르지 않는 경우")
-	@Test
-	void test_login_bad_request() throws Exception {
-		String username = "test123";
-		LoginRequest loginRequest = new LoginRequest(username, null);
-		String content = objectMapper.writeValueAsString(loginRequest);
-
-		String response = mockMvc.perform(post(UrlContext.LOGIN_URL)
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(content)
-				.with(csrf()))
-			.andExpect(status().isOk())
-			.andDo(print())
-			.andReturn()
-			.getResponse()
-			.getContentAsString(StandardCharsets.UTF_8);
-
-		BaseResponse<String> actual = objectMapper.readValue(response, BaseResponse.class);
-
-		assertThat(actual.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.name());
-	}
-
-	private static Stream<Arguments> loginArguments() {
-		return Stream.of(
-			Arguments.of(EntityNotFoundException.class, HttpStatus.NOT_FOUND),
-			Arguments.of(WrongPasswordException.class, HttpStatus.UNAUTHORIZED)
-		);
-	}
+    private static Stream<Arguments> loginArguments() {
+        return Stream.of(
+                Arguments.of(EntityNotFoundException.class, HttpStatus.NOT_FOUND),
+                Arguments.of(WrongPasswordException.class, HttpStatus.UNAUTHORIZED)
+        );
+    }
 }

--- a/feedbook/src/test/java/com/guardjo/feedbook/controller/FeedCommentControllerTest.java
+++ b/feedbook/src/test/java/com/guardjo/feedbook/controller/FeedCommentControllerTest.java
@@ -1,15 +1,22 @@
 package com.guardjo.feedbook.controller;
 
-import static org.assertj.core.api.AssertionsForClassTypes.*;
-import static org.mockito.BDDMockito.*;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
-import java.nio.charset.StandardCharsets;
-import java.util.List;
-
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.guardjo.feedbook.config.SecurityConfig;
+import com.guardjo.feedbook.config.auth.AccountPrincipal;
+import com.guardjo.feedbook.config.auth.JwtAuthManager;
+import com.guardjo.feedbook.controller.request.FeedCommentCreateRequest;
+import com.guardjo.feedbook.controller.response.BaseResponse;
+import com.guardjo.feedbook.controller.response.FeedCommentDto;
+import com.guardjo.feedbook.controller.response.FeedCommentPageDto;
+import com.guardjo.feedbook.model.domain.Feed;
+import com.guardjo.feedbook.model.domain.FeedComment;
+import com.guardjo.feedbook.model.domain.types.AlarmArgs;
+import com.guardjo.feedbook.model.domain.types.AlarmType;
+import com.guardjo.feedbook.service.FeedAlarmService;
+import com.guardjo.feedbook.service.FeedCommentService;
+import com.guardjo.feedbook.util.JwtProvider;
+import com.guardjo.feedbook.util.TestDataGenerator;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -29,156 +36,140 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.test.web.servlet.MockMvc;
 
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.guardjo.feedbook.config.SecurityConfig;
-import com.guardjo.feedbook.config.auth.AccountPrincipal;
-import com.guardjo.feedbook.config.auth.JwtAuthManager;
-import com.guardjo.feedbook.controller.request.FeedCommentCreateRequest;
-import com.guardjo.feedbook.controller.response.BaseResponse;
-import com.guardjo.feedbook.controller.response.FeedCommentDto;
-import com.guardjo.feedbook.controller.response.FeedCommentPageDto;
-import com.guardjo.feedbook.model.domain.Feed;
-import com.guardjo.feedbook.model.domain.FeedComment;
-import com.guardjo.feedbook.model.domain.types.AlarmArgs;
-import com.guardjo.feedbook.model.domain.types.AlarmType;
-import com.guardjo.feedbook.service.FeedAlarmService;
-import com.guardjo.feedbook.service.FeedCommentService;
-import com.guardjo.feedbook.util.JwtProvider;
-import com.guardjo.feedbook.util.TestDataGenerator;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @Import(SecurityConfig.class)
 @WebMvcTest(controllers = FeedCommentController.class)
 class FeedCommentControllerTest {
-	@Autowired
-	private MockMvc mockMvc;
-	@Autowired
-	private ObjectMapper objectMapper;
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
 
-	@MockBean
-	private JwtProvider jwtProvider;
-	@MockBean
-	private JwtAuthManager jwtAuthManager;
-	@MockBean
-	private FeedCommentService feedCommentService;
-	@MockBean
-	private FeedAlarmService feedAlarmService;
+    @MockBean
+    private JwtProvider jwtProvider;
+    @MockBean
+    private JwtAuthManager jwtAuthManager;
+    @MockBean
+    private FeedCommentService feedCommentService;
+    @MockBean
+    private FeedAlarmService feedAlarmService;
 
-	private final static String TEST_TOKEN = "Bearer Test";
-	private final static AccountPrincipal TEST_PRINCIPAL = TestDataGenerator.accountPrincipal(1L, "Tester");
+    private final static String TEST_TOKEN = "Bearer Test";
+    private final static AccountPrincipal TEST_PRINCIPAL = TestDataGenerator.accountPrincipal(1L, "Tester");
 
-	@BeforeEach
-	void setUp() {
-		Authentication authentication = new UsernamePasswordAuthenticationToken(TEST_PRINCIPAL, TEST_PRINCIPAL, TEST_PRINCIPAL.getAuthorities());
+    @BeforeEach
+    void setUp() {
+        Authentication authentication = new UsernamePasswordAuthenticationToken(TEST_PRINCIPAL, TEST_PRINCIPAL, TEST_PRINCIPAL.getAuthorities());
 
-		given(jwtProvider.isExpired(eq(TEST_TOKEN))).willReturn(false);
-		given(jwtProvider.getUsername(eq(TEST_TOKEN))).willReturn(TEST_PRINCIPAL.getUsername());
-		given(jwtAuthManager.authenticate(any(Authentication.class))).willReturn(authentication);
-	}
+        given(jwtProvider.isExpired(eq(TEST_TOKEN))).willReturn(false);
+        given(jwtProvider.getUsername(eq(TEST_TOKEN))).willReturn(TEST_PRINCIPAL.getUsername());
+        given(jwtAuthManager.authenticate(any(Authentication.class))).willReturn(authentication);
+    }
 
-	@AfterEach
-	void tearDown() {
-		then(jwtProvider).should().isExpired(eq(TEST_TOKEN));
-		then(jwtProvider).should().getUsername(eq(TEST_TOKEN));
-		then(jwtAuthManager).should().authenticate(any(Authentication.class));
-	}
+    @AfterEach
+    void tearDown() {
+        then(jwtProvider).should().isExpired(eq(TEST_TOKEN));
+        then(jwtProvider).should().getUsername(eq(TEST_TOKEN));
+        then(jwtAuthManager).should().authenticate(any(Authentication.class));
+    }
 
-	@DisplayName("POST : " + UrlContext.FEED_COMMENTS_URL + " : 정상")
-	@Test
-	void test_saveFeedComment() throws Exception {
-		long feedId = 1L;
-		FeedCommentCreateRequest request = new FeedCommentCreateRequest("test");
-		String requestContent = objectMapper.writeValueAsString(request);
+    @DisplayName("POST : " + UrlContext.FEED_COMMENTS_URL + " : 정상")
+    @Test
+    void test_saveFeedComment() throws Exception {
+        long feedId = 1L;
+        FeedCommentCreateRequest request = new FeedCommentCreateRequest("test");
+        String requestContent = objectMapper.writeValueAsString(request);
 
-		willDoNothing().given(feedCommentService).createNewComment(eq(request.content()), eq(TEST_PRINCIPAL.getAccount()), eq(feedId));
-		willDoNothing().given(feedAlarmService).saveNewAlarm(eq(AlarmType.COMMENT), any(AlarmArgs.class), eq(feedId));
+        willDoNothing().given(feedCommentService).createNewComment(eq(request.content()), eq(TEST_PRINCIPAL.getAccount()), eq(feedId));
+        willDoNothing().given(feedAlarmService).saveNewAlarm(eq(AlarmType.COMMENT), any(AlarmArgs.class), eq(feedId));
 
-		String response = mockMvc.perform(post(UrlContext.FEED_COMMENTS_URL.replace("{feedId}", String.valueOf(feedId)))
-				.contentType(MediaType.APPLICATION_JSON)
-				.header(HttpHeaders.AUTHORIZATION, TEST_TOKEN)
-				.content(requestContent)
-				.with(csrf()))
-			.andDo(print())
-			.andExpect(status().isOk())
-			.andReturn()
-			.getResponse()
-			.getContentAsString(StandardCharsets.UTF_8);
+        String response = mockMvc.perform(post(UrlContext.FEED_COMMENTS_URL.replace("{feedId}", String.valueOf(feedId)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, TEST_TOKEN)
+                        .content(requestContent)
+                        .with(csrf()))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString(StandardCharsets.UTF_8);
 
-		JavaType javaType = objectMapper.getTypeFactory().constructParametricType(BaseResponse.class, String.class);
-		BaseResponse<String> actual = objectMapper.readValue(response, javaType);
+        JavaType javaType = objectMapper.getTypeFactory().constructParametricType(BaseResponse.class, String.class);
+        BaseResponse<String> actual = objectMapper.readValue(response, javaType);
 
-		assertThat(actual).isNotNull();
-		assertThat(actual).isEqualTo(BaseResponse.defaultSuccesses());
+        assertThat(actual).isNotNull();
+        assertThat(actual).isEqualTo(BaseResponse.defaultSuccesses());
 
-		then(feedCommentService).should().createNewComment(eq(request.content()), eq(TEST_PRINCIPAL.getAccount()), eq(feedId));
-		then(feedAlarmService).should().saveNewAlarm(eq(AlarmType.COMMENT), any(AlarmArgs.class), eq(feedId));
-	}
+        then(feedCommentService).should().createNewComment(eq(request.content()), eq(TEST_PRINCIPAL.getAccount()), eq(feedId));
+        then(feedAlarmService).should().saveNewAlarm(eq(AlarmType.COMMENT), any(AlarmArgs.class), eq(feedId));
+    }
 
-	@DisplayName("POST : " + UrlContext.FEED_COMMENTS_URL + " : 입력값이 잘못된 경우")
-	@Test
-	void test_saveFeedComment_BadRequest() throws Exception {
-		long feedId = 1L;
-		FeedCommentCreateRequest request = new FeedCommentCreateRequest("");
-		String requestContent = objectMapper.writeValueAsString(request);
+    @DisplayName("POST : " + UrlContext.FEED_COMMENTS_URL + " : 입력값이 잘못된 경우")
+    @Test
+    void test_saveFeedComment_BadRequest() throws Exception {
+        long feedId = 1L;
+        FeedCommentCreateRequest request = new FeedCommentCreateRequest("");
+        String requestContent = objectMapper.writeValueAsString(request);
 
-		willDoNothing().given(feedCommentService).createNewComment(eq(request.content()), eq(TEST_PRINCIPAL.getAccount()), eq(feedId));
+        willDoNothing().given(feedCommentService).createNewComment(eq(request.content()), eq(TEST_PRINCIPAL.getAccount()), eq(feedId));
 
-		String response = mockMvc.perform(post(UrlContext.FEED_COMMENTS_URL.replace("{feedId}", String.valueOf(feedId)))
-				.contentType(MediaType.APPLICATION_JSON)
-				.header(HttpHeaders.AUTHORIZATION, TEST_TOKEN)
-				.content(requestContent)
-				.with(csrf()))
-			.andDo(print())
-			.andExpect(status().isOk())
-			.andReturn()
-			.getResponse()
-			.getContentAsString(StandardCharsets.UTF_8);
+        mockMvc.perform(post(UrlContext.FEED_COMMENTS_URL.replace("{feedId}", String.valueOf(feedId)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, TEST_TOKEN)
+                        .content(requestContent)
+                        .with(csrf()))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
 
-		JavaType javaType = objectMapper.getTypeFactory().constructParametricType(BaseResponse.class, String.class);
-		BaseResponse<String> actual = objectMapper.readValue(response, javaType);
+    @DisplayName("GET : " + UrlContext.FEED_COMMENTS_URL + " : 정상")
+    @Test
+    void test_getFeedComment() throws Exception {
+        long feedId = 1L;
+        int page = 0;
+        int size = 10;
+        Feed feed = TestDataGenerator.feed(1L, "Test", "test", TEST_PRINCIPAL.getAccount());
+        List<FeedComment> feedCommentList = List.of(
+                TestDataGenerator.feedComment(1L, "test", feed, TEST_PRINCIPAL.getAccount()),
+                TestDataGenerator.feedComment(2L, "test2", feed, TEST_PRINCIPAL.getAccount())
+        );
+        Pageable pageable = PageRequest.of(page, size);
+        Page<FeedComment> feedCommentPage = new PageImpl<>(feedCommentList, pageable, feedCommentList.size());
+        List<FeedCommentDto> expected = feedCommentPage.getContent().stream()
+                .map(FeedCommentDto::from)
+                .toList();
 
-		assertThat(actual).isNotNull();
-		assertThat(actual.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.name());
-	}
+        given(feedCommentService.findAllFeedComments(any(Pageable.class), eq(feedId))).willReturn(feedCommentPage);
 
-	@DisplayName("GET : " + UrlContext.FEED_COMMENTS_URL + " : 정상")
-	@Test
-	void test_getFeedComment() throws Exception {
-		long feedId = 1L;
-		int page = 0;
-		int size = 10;
-		Feed feed = TestDataGenerator.feed(1L, "Test", "test", TEST_PRINCIPAL.getAccount());
-		List<FeedComment> feedCommentList = List.of(
-			TestDataGenerator.feedComment(1L, "test", feed, TEST_PRINCIPAL.getAccount()),
-			TestDataGenerator.feedComment(2L, "test2", feed, TEST_PRINCIPAL.getAccount())
-		);
-		Pageable pageable = PageRequest.of(page, size);
-		Page<FeedComment> feedCommentPage = new PageImpl<>(feedCommentList, pageable, feedCommentList.size());
-		List<FeedCommentDto> expected = feedCommentPage.getContent().stream()
-			.map(FeedCommentDto::from)
-			.toList();
+        String response = mockMvc.perform(get(UrlContext.FEED_COMMENTS_URL.replace("{feedId}", String.valueOf(feedId)))
+                        .requestAttr("size", size)
+                        .requestAttr("page", page)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, TEST_TOKEN)
+                        .with(csrf()))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString(StandardCharsets.UTF_8);
 
-		given(feedCommentService.findAllFeedComments(any(Pageable.class), eq(feedId))).willReturn(feedCommentPage);
+        JavaType javaType = objectMapper.getTypeFactory().constructParametricType(BaseResponse.class, FeedCommentPageDto.class);
+        BaseResponse<FeedCommentPageDto> actual = objectMapper.readValue(response, javaType);
 
-		String response = mockMvc.perform(get(UrlContext.FEED_COMMENTS_URL.replace("{feedId}", String.valueOf(feedId)))
-				.requestAttr("size", size)
-				.requestAttr("page", page)
-				.contentType(MediaType.APPLICATION_JSON)
-				.header(HttpHeaders.AUTHORIZATION, TEST_TOKEN)
-				.with(csrf()))
-			.andDo(print())
-			.andExpect(status().isOk())
-			.andReturn()
-			.getResponse()
-			.getContentAsString(StandardCharsets.UTF_8);
+        assertThat(actual).isNotNull();
+        assertThat(actual.getStatus()).isEqualTo(HttpStatus.OK.name());
+        assertThat(actual.getBody().comments()).isEqualTo(expected);
 
-		JavaType javaType = objectMapper.getTypeFactory().constructParametricType(BaseResponse.class, FeedCommentPageDto.class);
-		BaseResponse<FeedCommentPageDto> actual = objectMapper.readValue(response, javaType);
-
-		assertThat(actual).isNotNull();
-		assertThat(actual.getStatus()).isEqualTo(HttpStatus.OK.name());
-		assertThat(actual.getBody().comments()).isEqualTo(expected);
-
-		then(feedCommentService).should().findAllFeedComments(any(Pageable.class), eq(feedId));
-	}
+        then(feedCommentService).should().findAllFeedComments(any(Pageable.class), eq(feedId));
+    }
 }


### PR DESCRIPTION
- Jwt 유틸 객체에서 던지던 Expired 관련 예외를 밖에서 처리하도록 명시
- API 응답 간 예외 발생 시 http 상태 코드를 기반으로 반환하도록 개선

closes #75 