### PR TITLE
[BE[ #53 API 문서 개선 및 최신화

### DIFF
--- a/feedbook/src/main/java/com/guardjo/feedbook/config/SwaggerConfig.java
+++ b/feedbook/src/main/java/com/guardjo/feedbook/config/SwaggerConfig.java
@@ -5,8 +5,11 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
 
 @Configuration
 public class SwaggerConfig {
@@ -24,10 +27,10 @@ public class SwaggerConfig {
                 );
 
         return new OpenAPI()
+                .servers(List.of(new Server().url("/")))
                 .components(components)
                 .info(apiInfo())
-                .addSecurityItem(securityRequirement)
-                .components(components);
+                .addSecurityItem(securityRequirement);
     }
 
     private Info apiInfo() {

--- a/feedbook/src/main/java/com/guardjo/feedbook/controller/AccountController.java
+++ b/feedbook/src/main/java/com/guardjo/feedbook/controller/AccountController.java
@@ -1,5 +1,6 @@
 package com.guardjo.feedbook.controller;
 
+import com.guardjo.feedbook.controller.docs.AccountApiDoc;
 import com.guardjo.feedbook.controller.request.LoginRequest;
 import com.guardjo.feedbook.controller.request.SignupRequest;
 import com.guardjo.feedbook.controller.response.BaseResponse;
@@ -18,10 +19,11 @@ import java.util.Objects;
 @RestController
 @Slf4j
 @RequiredArgsConstructor
-public class AccountController {
+public class AccountController implements AccountApiDoc {
     private final AccountService accountService;
 
     @PostMapping(UrlContext.SIGNUP_URL)
+    @Override
     public BaseResponse<String> signup(@RequestBody SignupRequest signupRequest) {
         log.info("POST : {}, username = {}", UrlContext.SIGNUP_URL, signupRequest.username());
 
@@ -39,6 +41,7 @@ public class AccountController {
     }
 
     @PostMapping(UrlContext.LOGIN_URL)
+    @Override
     public BaseResponse<String> login(@RequestBody LoginRequest loginRequest) {
         log.info("POST : {}, username = {}", UrlContext.LOGIN_URL, loginRequest.username());
 

--- a/feedbook/src/main/java/com/guardjo/feedbook/controller/AlarmController.java
+++ b/feedbook/src/main/java/com/guardjo/feedbook/controller/AlarmController.java
@@ -1,37 +1,37 @@
 package com.guardjo.feedbook.controller;
 
 import com.guardjo.feedbook.config.auth.AccountPrincipal;
+import com.guardjo.feedbook.controller.docs.AlarmApiDoc;
 import com.guardjo.feedbook.controller.response.BaseResponse;
 import com.guardjo.feedbook.controller.response.FeedAlarmPageDto;
 import com.guardjo.feedbook.model.domain.Account;
 import com.guardjo.feedbook.service.FeedAlarmService;
+import com.guardjo.feedbook.util.PaginationUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @CrossOrigin(maxAge = 3600)
 @RestController
 @RequiredArgsConstructor
 @Slf4j
-public class AlarmController {
+public class AlarmController implements AlarmApiDoc {
     private final FeedAlarmService feedAlarmService;
 
     @GetMapping(UrlContext.ALARMS_URL)
+    @Override
     public BaseResponse<FeedAlarmPageDto> getAlarms(@AuthenticationPrincipal AccountPrincipal principal,
-                                                    @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+                                                    @RequestParam("page") int pageNumber,
+                                                    @RequestParam(value = "size", required = false, defaultValue = "10") int pageSize) {
         Account account = principal.getAccount();
         log.info("GET : " + UrlContext.ALARMS_URL + " accountId = {}", account.getId());
 
+        Pageable pageable = PaginationUtils.fromSortByCreatedAtDesc(pageNumber, pageSize);
         FeedAlarmPageDto feedAlarmPageDto = feedAlarmService.findAllFeedAlarmByAccount(account, pageable);
 
         return BaseResponse.<FeedAlarmPageDto>builder()
@@ -41,6 +41,7 @@ public class AlarmController {
     }
 
     @DeleteMapping(UrlContext.ALARMS_URL)
+    @Override
     public BaseResponse<String> deleteAllAlarms(@AuthenticationPrincipal AccountPrincipal principal) {
         Account account = principal.getAccount();
         log.info("DELETE : " + UrlContext.ALARMS_URL + " accountId = {}", account.getId());
@@ -51,6 +52,7 @@ public class AlarmController {
     }
 
     @GetMapping(value = UrlContext.ALARM_SUB_URL, produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    @Override
     public SseEmitter connectAlarms(@AuthenticationPrincipal AccountPrincipal principal) {
         Account account = principal.getAccount();
 

--- a/feedbook/src/main/java/com/guardjo/feedbook/controller/FeedController.java
+++ b/feedbook/src/main/java/com/guardjo/feedbook/controller/FeedController.java
@@ -1,6 +1,7 @@
 package com.guardjo.feedbook.controller;
 
 import com.guardjo.feedbook.config.auth.AccountPrincipal;
+import com.guardjo.feedbook.controller.docs.FeedApiDoc;
 import com.guardjo.feedbook.controller.request.FeedCreateRequest;
 import com.guardjo.feedbook.controller.request.FeedModifyRequest;
 import com.guardjo.feedbook.controller.response.BaseResponse;
@@ -11,11 +12,11 @@ import com.guardjo.feedbook.model.domain.types.AlarmArgs;
 import com.guardjo.feedbook.model.domain.types.AlarmType;
 import com.guardjo.feedbook.service.FeedAlarmService;
 import com.guardjo.feedbook.service.FeedService;
+import com.guardjo.feedbook.util.PaginationUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -26,11 +27,12 @@ import java.util.List;
 @RestController
 @Slf4j
 @RequiredArgsConstructor
-public class FeedController {
+public class FeedController implements FeedApiDoc {
     private final FeedService feedService;
     private final FeedAlarmService feedAlarmService;
 
     @PostMapping(UrlContext.FEEDS_URL)
+    @Override
     public BaseResponse<String> createFeed(@RequestBody FeedCreateRequest feedCreateRequest, @AuthenticationPrincipal AccountPrincipal principal) {
         log.info("POST : {}, username = {}", UrlContext.FEEDS_URL, principal.getUsername());
 
@@ -46,11 +48,15 @@ public class FeedController {
     }
 
     @GetMapping(UrlContext.FEEDS_URL)
-    public BaseResponse<FeedPageDto> getFeedPage(@PageableDefault Pageable pageable, @AuthenticationPrincipal AccountPrincipal principal) {
+    @Override
+    public BaseResponse<FeedPageDto> getFeedPage(@AuthenticationPrincipal AccountPrincipal principal,
+                                                 @RequestParam("page") int pageNumber,
+                                                 @RequestParam(value = "size", required = false, defaultValue = "10") int pageSize) {
         log.info("GET : {}, username = {}", UrlContext.FEEDS_URL, principal.getUsername());
 
         Account account = principal.getAccount();
 
+        Pageable pageable = PaginationUtils.fromSortByCreatedAtDesc(pageNumber, pageSize);
         Page<FeedDto> feeds = feedService.getAllFeeds(pageable, account);
 
         FeedPageDto feedPageDto = initFeedPageDto(feeds);
@@ -62,11 +68,15 @@ public class FeedController {
     }
 
     @GetMapping(UrlContext.MY_FEEDS_URL)
-    public BaseResponse<FeedPageDto> getMyFeedPage(@PageableDefault Pageable pageable, @AuthenticationPrincipal AccountPrincipal principal) {
+    @Override
+    public BaseResponse<FeedPageDto> getMyFeedPage(@AuthenticationPrincipal AccountPrincipal principal,
+                                                   @RequestParam("page") int pageNumber,
+                                                   @RequestParam(value = "size", required = false, defaultValue = "10") int pageSize) {
         log.info("GET : {}, username = {}", UrlContext.MY_FEEDS_URL, principal.getUsername());
 
         Account account = principal.getAccount();
 
+        Pageable pageable = PaginationUtils.fromSortByCreatedAtDesc(pageNumber, pageSize);
         Page<FeedDto> feeds = feedService.getMyFeeds(pageable, account);
 
         FeedPageDto feedPageDto = initFeedPageDto(feeds);
@@ -78,6 +88,7 @@ public class FeedController {
     }
 
     @PatchMapping(UrlContext.FEEDS_URL)
+    @Override
     public BaseResponse<String> updateFeed(@RequestBody FeedModifyRequest feedModifyRequest, @AuthenticationPrincipal AccountPrincipal principal) {
         log.info("PATCH : {}, username = {}", UrlContext.FEEDS_URL, principal.getUsername());
 
@@ -93,6 +104,7 @@ public class FeedController {
     }
 
     @DeleteMapping(UrlContext.FEEDS_URL + "/{feedId}")
+    @Override
     public BaseResponse<String> deleteFeed(@PathVariable long feedId, @AuthenticationPrincipal AccountPrincipal principal) {
         log.info("DELETE : {}/{}, username = {}", UrlContext.FEEDS_URL, feedId, principal.getUsername());
 
@@ -102,6 +114,7 @@ public class FeedController {
     }
 
     @PutMapping(UrlContext.FAVORITE_FEEDS_URL + "/{feedId}")
+    @Override
     public BaseResponse<String> updateFavoriteFeed(@PathVariable long feedId, @AuthenticationPrincipal AccountPrincipal principal) {
         Account account = principal.getAccount();
         log.info("PUT : {}/{}, username = {}", UrlContext.FAVORITE_FEEDS_URL, feedId, principal.getUsername());

--- a/feedbook/src/main/java/com/guardjo/feedbook/controller/docs/AccountApiDoc.java
+++ b/feedbook/src/main/java/com/guardjo/feedbook/controller/docs/AccountApiDoc.java
@@ -1,0 +1,16 @@
+package com.guardjo.feedbook.controller.docs;
+
+import com.guardjo.feedbook.controller.request.LoginRequest;
+import com.guardjo.feedbook.controller.request.SignupRequest;
+import com.guardjo.feedbook.controller.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "회원", description = "회원 관련 API")
+public interface AccountApiDoc {
+    @Operation(summary = "회원가입", description = "신규 회원 정보를 저장한다.")
+    BaseResponse<String> signup(SignupRequest signupRequest);
+
+    @Operation(summary = "로그인", description = "저장된 회원 정보를 기반으로 Access Token을 반환한다.")
+    BaseResponse<String> login(LoginRequest loginRequest);
+}

--- a/feedbook/src/main/java/com/guardjo/feedbook/controller/docs/AlarmApiDoc.java
+++ b/feedbook/src/main/java/com/guardjo/feedbook/controller/docs/AlarmApiDoc.java
@@ -1,0 +1,29 @@
+package com.guardjo.feedbook.controller.docs;
+
+import com.guardjo.feedbook.config.auth.AccountPrincipal;
+import com.guardjo.feedbook.controller.response.BaseResponse;
+import com.guardjo.feedbook.controller.response.FeedAlarmPageDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.MediaType;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Tag(name = "알림", description = "알림 관련 API")
+public interface AlarmApiDoc {
+    @Operation(summary = "알림 목록 조회", description = "페이지네이션 요청에 따른 현재 계정의 알림 목록을 반환한다.")
+    BaseResponse<FeedAlarmPageDto> getAlarms(AccountPrincipal principal, int pageNumber, int pageSize);
+
+    @Operation(summary = "알림 전체 삭제", description = "현재 계정의 알림들을 모두 삭제한다.")
+    BaseResponse<String> deleteAllAlarms(AccountPrincipal principal);
+
+    @Operation(summary = "알림 SSE 연결", description = "현재 계정의 생성되는 알림들을 SSE로 수신받도록 연결한다.",
+            responses = {
+                    @ApiResponse(content = {
+                            @Content(mediaType = MediaType.TEXT_EVENT_STREAM_VALUE)
+                    })
+            }
+    )
+    SseEmitter connectAlarms(AccountPrincipal principal);
+}

--- a/feedbook/src/main/java/com/guardjo/feedbook/controller/docs/FeedApiDoc.java
+++ b/feedbook/src/main/java/com/guardjo/feedbook/controller/docs/FeedApiDoc.java
@@ -1,0 +1,30 @@
+package com.guardjo.feedbook.controller.docs;
+
+import com.guardjo.feedbook.config.auth.AccountPrincipal;
+import com.guardjo.feedbook.controller.request.FeedCreateRequest;
+import com.guardjo.feedbook.controller.request.FeedModifyRequest;
+import com.guardjo.feedbook.controller.response.BaseResponse;
+import com.guardjo.feedbook.controller.response.FeedPageDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "피드", description = "피드 관련 API")
+public interface FeedApiDoc {
+    @Operation(summary = "피드 생성", description = "주어진 데이터를 기반으로 신규 피드를 저장한다.")
+    BaseResponse<String> createFeed(FeedCreateRequest request, AccountPrincipal principal);
+
+    @Operation(summary = "피드 목록 조회", description = "현재 저장된 피드 목록을 조회한다.")
+    BaseResponse<FeedPageDto> getFeedPage(AccountPrincipal principal, int pageNumber, int pageSize);
+
+    @Operation(summary = "자신의 피드 목록 조회", description = "현재 계정이 저장한 피드 목록을 조회한다.")
+    BaseResponse<FeedPageDto> getMyFeedPage(AccountPrincipal principal, int pageNumber, int pageSize);
+
+    @Operation(summary = "피드 갱신", description = "특정 피드의 데이터를 수정한다.")
+    BaseResponse<String> updateFeed(FeedModifyRequest feedModifyRequest, AccountPrincipal principal);
+
+    @Operation(summary = "피드 삭제", description = "특정 피드를 삭제한다.")
+    BaseResponse<String> deleteFeed(long feedId, AccountPrincipal principal);
+
+    @Operation(summary = "피드 즐겨찾기 갱신", description = "특정 피드에 대한 즐겨찾기 여부를 갱신한다.")
+    BaseResponse<String> updateFavoriteFeed(long feedId, AccountPrincipal principal);
+}

--- a/feedbook/src/main/java/com/guardjo/feedbook/controller/docs/FeedCommentApiDoc.java
+++ b/feedbook/src/main/java/com/guardjo/feedbook/controller/docs/FeedCommentApiDoc.java
@@ -1,0 +1,17 @@
+package com.guardjo.feedbook.controller.docs;
+
+import com.guardjo.feedbook.config.auth.AccountPrincipal;
+import com.guardjo.feedbook.controller.request.FeedCommentCreateRequest;
+import com.guardjo.feedbook.controller.response.BaseResponse;
+import com.guardjo.feedbook.controller.response.FeedCommentPageDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "피드 댓글", description = "피드 댓글 관련 API")
+public interface FeedCommentApiDoc {
+    @Operation(summary = "신규 댓글 저장", description = "특정 피드에 신규 댓글 정보를 저장한다.")
+    BaseResponse<String> saveFeedComment(FeedCommentCreateRequest request, long feedId, AccountPrincipal principal);
+
+    @Operation(summary = "피드 댓글 목록 조회", description = "특정 피드에 등록된 댓글 목록을 반환한다.")
+    BaseResponse<FeedCommentPageDto> getFeedComment(long feedId, int pageNumber, int pageSize, AccountPrincipal principal);
+}

--- a/feedbook/src/main/java/com/guardjo/feedbook/util/PaginationUtils.java
+++ b/feedbook/src/main/java/com/guardjo/feedbook/util/PaginationUtils.java
@@ -1,0 +1,40 @@
+package com.guardjo.feedbook.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PaginationUtils {
+    private final static int DEFAULT_PAGE_SIZE = 10;
+    private final static Sort DEFAULT_SORT_BY_CREATED_AT_DESC = Sort.by(Sort.Order.desc("createdAt"));
+
+    /**
+     * <p>주어진 페이지 번호에 대한 Pageable 객체 반환<p>
+     * <hr/>
+     * <i>기본 정렬 : BaseEntity의 createdAt 기준 내림차 순 정렬</i>
+     *
+     * @param pageNumber 페이지 번호
+     * @return Pageable
+     * @see com.guardjo.feedbook.model.domain.BaseEntity
+     */
+    public static Pageable fromSortByCreatedAtDesc(int pageNumber) {
+        return fromSortByCreatedAtDesc(pageNumber, DEFAULT_PAGE_SIZE);
+    }
+
+    /**
+     * <p>주어진 페이지 번호 및 페이지 크기에 따른 Pageable 객체 반환<p>
+     * <hr/>
+     * <i>기본 정렬 : BaseEntity의 createdAt 기준 내림차 순 정렬</i>
+     *
+     * @param pageNumber 페이지 번호
+     * @param pageSize   페이지 크기
+     * @return Pageable
+     * @see com.guardjo.feedbook.model.domain.BaseEntity
+     */
+    public static Pageable fromSortByCreatedAtDesc(int pageNumber, int pageSize) {
+        return PageRequest.of(pageNumber, pageSize, DEFAULT_SORT_BY_CREATED_AT_DESC);
+    }
+}

--- a/feedbook/src/test/java/com/guardjo/feedbook/controller/AlarmControllerTest.java
+++ b/feedbook/src/test/java/com/guardjo/feedbook/controller/AlarmControllerTest.java
@@ -90,6 +90,7 @@ class AlarmControllerTest {
         given(feedAlarmService.findAllFeedAlarmByAccount(eq(TEST_PRINCIPAL.getAccount()), any(Pageable.class))).willReturn(expected);
 
         String response = mockMvc.perform(get(UrlContext.ALARMS_URL)
+                        .param("page", "0")
                         .header(HttpHeaders.AUTHORIZATION, TEST_TOKEN)
                         .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON))
                 .andDo(print())
@@ -146,7 +147,7 @@ class AlarmControllerTest {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(content().string(String.format("data:%s\n\n", expected)));
-		
+
         then(feedAlarmService).should().connectAlarmSubscriber(eq(TEST_PRINCIPAL.getAccount().getId()));
     }
 }

--- a/feedbook/src/test/java/com/guardjo/feedbook/controller/FeedCommentControllerTest.java
+++ b/feedbook/src/test/java/com/guardjo/feedbook/controller/FeedCommentControllerTest.java
@@ -152,8 +152,8 @@ class FeedCommentControllerTest {
         given(feedCommentService.findAllFeedComments(any(Pageable.class), eq(feedId))).willReturn(feedCommentPage);
 
         String response = mockMvc.perform(get(UrlContext.FEED_COMMENTS_URL.replace("{feedId}", String.valueOf(feedId)))
-                        .requestAttr("size", size)
-                        .requestAttr("page", page)
+                        .param("page", String.valueOf(page))
+                        .param("size", String.valueOf(size))
                         .contentType(MediaType.APPLICATION_JSON)
                         .header(HttpHeaders.AUTHORIZATION, TEST_TOKEN)
                         .with(csrf()))

--- a/feedbook/src/test/java/com/guardjo/feedbook/controller/FeedControllerTest.java
+++ b/feedbook/src/test/java/com/guardjo/feedbook/controller/FeedControllerTest.java
@@ -120,6 +120,7 @@ class FeedControllerTest {
         given(feedService.getAllFeeds(any(Pageable.class), any(Account.class))).willReturn(feeds);
 
         String response = mockMvc.perform(get(UrlContext.FEEDS_URL)
+                        .param("page", "0")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header(HttpHeaders.AUTHORIZATION, token))
                 .andDo(print())
@@ -150,6 +151,7 @@ class FeedControllerTest {
         given(feedService.getMyFeeds(any(Pageable.class), eq(TEST_PRINCIPAL.getAccount()))).willReturn(feeds);
 
         String response = mockMvc.perform(get(UrlContext.MY_FEEDS_URL)
+                        .param("page", "0")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header(HttpHeaders.AUTHORIZATION, token))
                 .andDo(print())


### PR DESCRIPTION
- 기존 컨트롤러 객체와 swagger 문서화 인터페이스 분리
- 기존 pageable 을 인자로 받던 API들 개선
    - pageable 객체가 아닌 pageNumber, pageSize를 별개로 받도록 개선
    - BaseEntity의 createdAt을 기준으로 하는 기본 Pageable 구성 유틸 별도 구성
- 테스트 코드 개선

closes #53 